### PR TITLE
chore: relax vitest peer dependency version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/sapphi-red/vitest-github-actions-reporter#readme",
   "peerDependencies": {
-    "vitest": "^0.16.0"
+    "vitest": ">=0.16.0"
   },
   "devDependencies": {
     "@types/node": "^16.11.41",


### PR DESCRIPTION
Switch it from `~0.16.0` to `>=0.16.0` because `~` will fixate the first non-zero number