### PR TITLE
Add support for source maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "vitest-github-actions-reporter",
-  "version": "0.8.1",
+  "version": "0.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitest-github-actions-reporter",
-      "version": "0.8.1",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.9.0"
+        "@actions/core": "^1.9.0",
+        "source-map-js": "^1.0.2"
       },
       "devDependencies": {
         "@types/node": "^16.11.41",
@@ -27,7 +28,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "vitest": "^0.16.0"
+        "vitest": ">=0.16.0"
       }
     },
     "node_modules/@actions/core": {
@@ -2311,7 +2312,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4366,8 +4366,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "strip-ansi": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "vitest": "^0.16.0"
   },
   "dependencies": {
-    "@actions/core": "^1.9.0"
+    "@actions/core": "^1.9.0",
+    "source-map-js": "^1.0.2"
   }
 }


### PR DESCRIPTION
This correctly takes into account source maps for compile-to-js languages. I added this to support pointing to the exact line and column in Imba, but it works whenever there are sourcemaps.

You can see it in action here that's using a published fork of your library https://stackblitz.com/edit/github-2jxdgl?file=test%2Fbasic.test.imba