### PR TITLE
docs: do not hide default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import GithubActionsReporter from 'vitest-github-actions-reporter'
 export default {
   test: {
     reporters: process.env.GITHUB_ACTIONS
-      ? new GithubActionsReporter()
+      ? ['default', new GithubActionsReporter()]
       : 'default'
   }
 }


### PR DESCRIPTION
With the currently proposed config, the default output by vitest is hidden. In most situations, this is probably not what you want. So I changed the recommended config to keep the default output but enrich it by github annotations.